### PR TITLE
initial creation of 2019-09 orbit alias

### DIFF
--- a/orbit/2019-09/compositeArtifacts.xml
+++ b/orbit/2019-09/compositeArtifacts.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?compositeArtifactRepository version='1.0.0'?>
+<repository name="Xtext 2.19 Orbit Alias" type="org.eclipse.equinox.internal.p2.artifact.repository.CompositeArtifactRepository" version="1.0.0">
+  <properties size="1">
+    <property name="p2.timestamp" value="1554380216120"/>
+  </properties>
+  <children size="1">
+    <child location="https://download.eclipse.org/tools/orbit/downloads/2019-06/"/>
+  </children>
+</repository>

--- a/orbit/2019-09/compositeContent.xml
+++ b/orbit/2019-09/compositeContent.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<?compositeMetadataRepository version='1.0.0'?>
+<repository name="Xtext 2.19 Orbit Alias" type="org.eclipse.equinox.internal.p2.metadata.repository.CompositeMetadataRepository" version="1.0.0">
+  <properties size="1">
+    <property name="p2.timestamp" value="1554380216120"/>
+  </properties>
+  <children size="1">
+    <child location="https://download.eclipse.org/tools/orbit/downloads/2019-06/"/>
+  </children>
+</repository>


### PR DESCRIPTION
initial creation of 2019-09 orbit alias
(the orbit side is not available yet thus we use 2019-06)
Signed-off-by: Christian Dietrich <christian.dietrich@itemis.de>